### PR TITLE
feat: add latex skill for academic writing conventions

### DIFF
--- a/.claude/skills/latex/SKILL.md
+++ b/.claude/skills/latex/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: latex
+description: >-
+  LaTeX document writing for academic writing.
+  Enforces consistent equation layout, labelling, and
+  typographic conventions. Triggers on any .tex editing,
+  equation writing, LaTeX compilation, or LaTeX project
+  initialization task.
+---
+
+# LaTeX Conventions for Academic Reports
+
+## 1. Engine & Build
+
+- Always use `xelatex`, never `pdflatex`.
+- Magic comment at top of file: `% !TEX program = xelatex`
+
+## 2. Multi-Step Derivations (CRITICAL)
+
+This is the single most important rule.
+
+**One `align` environment for the entire derivation.**
+Each algebraic step is a new `&=` line.
+Never break a derivation into separate equation environments.
+
+```latex
+\begin{align}
+%--- definition ---
+\mathbf{J}
+  &= \frac{\partial \mathbf{f}}{\partial \mathbf{q}}
+     \notag \\[0.8em]
+%--- chain rule expansion ---
+  &= \begin{pmatrix}
+       \dfrac{\partial f_1}{\partial q_1} & \cdots \\
+       \vdots & \ddots
+     \end{pmatrix}
+     \notag \\[0.8em]
+%--- substitution ---
+  &= \begin{pmatrix}
+       -L_1 s_1 & 0 \\
+        L_1 c_1 & 0
+     \end{pmatrix}
+     \label{eq:jacobian_final}
+\end{align}
+```
+
+Rules:
+- Separate steps with `\notag \\[0.8em]`
+- Add `%--- step name ---` comments between steps
+- Only the **final** line gets `\label{}`; all others get `\notag`
+- Chain-rule expansions go **inside** the same `align` as a new
+  `&=` `\begin{pmatrix}` line — never a separate environment
+
+## 3. Boxed Final Results
+
+Wrap important results in a boxed equation:
+
+```latex
+\begin{equation}\boxed{\begin{aligned}
+  x &= a + b \\
+  y &= c + d
+  \quad\text{for } t > 0
+\end{aligned}}\end{equation}
+```
+
+- Conditions go as `\quad\text{...}` inside the box.
+
+## 4. Tables
+
+```latex
+\begin{table}[H]
+  \centering
+  \caption{Description of the table.}
+  \label{tab:descriptive_name}
+  \begin{tabular}{lcc}
+    \toprule
+    Header & Col 1 & Col 2 \\
+    \midrule
+    Row 1  & val   & val   \\
+    \bottomrule
+  \end{tabular}
+\end{table}
+```
+
+- Always use `booktabs` (`\toprule`, `\midrule`, `\bottomrule`).
+- Always include `\caption` and `\label{tab:...}`.
+- Use `[H]` placement from the `float` package.
+
+## 5. Labels
+
+| Prefix | Object   | Example                          |
+|--------|----------|----------------------------------|
+| `eq:`  | Equation | `\label{eq:fk_serial}`           |
+| `tab:` | Table    | `\label{tab:dh_parameters}`      |
+| `fig:` | Figure   | `\label{fig:workspace_plot}`     |
+| `sec:` | Section  | `\label{sec:forward_kinematics}` |
+
+- Use `snake_case` descriptive names.
+
+## 6. Text Conventions
+
+- Non-breaking space with `~`:
+  `Link~1`, `Eq.~\eqref{eq:name}`, `Fig.~\ref{fig:name}`
+- Units via siunitx: `\SI{1.5}{m}`, `\SI{90}{\degree}`
+- One sentence per source line in `.tex` files.
+- After abbreviations: `e.g.\ `, `i.e.\ ` (backslash-space).
+
+## 7. Section Decoration
+
+```latex
+% ============================================================
+\section{Forward Kinematics}
+\label{sec:forward_kinematics}
+
+% ------------------------------------------------------------
+\subsection{Serial Manipulator}
+```
+
+- `%` + 60 `=` chars before `\section`
+- `%` + 60 `-` chars before `\subsection`
+
+## 8. Standard Preamble Packages
+
+```latex
+\usepackage[margin=1in]{geometry}
+\usepackage{amsmath,amssymb}
+\usepackage{booktabs}
+\usepackage{float}
+\usepackage{graphicx}
+\usepackage{listings}
+\usepackage{xcolor}
+\usepackage{hyperref}
+\usepackage{fancyhdr}
+\usepackage{siunitx}
+```
+
+- Pre-define code listing styles (arduino, python) as needed.
+- Load `hyperref` near the end to avoid option clashes.
+
+## 9. Project Structure
+
+See [reference/project_structure.md](reference/project_structure.md)
+for directory layout, `main.tex` skeleton, preamble template,
+`\input` vs `\include`, image management, `.gitignore`, and
+section file naming conventions.

--- a/.claude/skills/latex/references/project_structure.md
+++ b/.claude/skills/latex/references/project_structure.md
@@ -1,0 +1,138 @@
+# LaTeX Project Structure & Initialization
+
+## Directory Layout
+
+```
+Project_Root/
+├── main.tex              # Entry point (skeleton only)
+├── references.bib        # Bibliography database
+├── sections/             # Chapter/section content
+│   ├── 01_xxx.tex
+│   ├── 02_xxx.tex
+│   └── ...
+├── figures/              # All image assets
+├── appendix/             # (Optional) Appendix content
+│   ├── A_xxx.tex
+│   └── B_xxx.tex
+├── styles/               # Preamble & custom packages
+│   └── preamble.tex
+└── output/               # (Optional) Build artifacts
+```
+
+### Section naming by document type
+
+**Research paper** — use standard paper sections:
+
+```
+sections/
+├── 00_abstract.tex
+├── 01_introduction.tex
+├── 02_methodology.tex
+├── 03_experiments.tex
+└── 04_conclusion.tex
+```
+
+**Homework / report / other** — name by topic, not paper structure:
+
+```
+sections/
+├── 01_forward_kinematics.tex
+├── 02_inverse_kinematics.tex
+├── 03_jacobian.tex
+└── 04_workspace_analysis.tex
+```
+
+Rule: always use numeric prefixes (`01_`, `02_`, ...) so files
+sort by logical order.
+
+## main.tex — Skeleton Only
+
+`main.tex` assembles parts; it must not contain actual content.
+
+```latex
+% !TEX program = xelatex
+\documentclass[12pt, a4paper]{article}
+
+\input{styles/preamble}
+
+\title{Your Title Here}
+\author{Author Name}
+\date{\today}
+
+\begin{document}
+\maketitle
+% \input{sections/00_abstract}   % paper only
+\tableofcontents
+\newpage
+
+\input{sections/01_xxx}
+\input{sections/02_xxx}
+
+% \appendix                       % uncomment if needed
+% \input{appendix/A_xxx}
+% \input{appendix/B_xxx}
+
+% \bibliographystyle{plain}      % uncomment if needed
+% \bibliography{references}
+\end{document}
+```
+
+## styles/preamble.tex
+
+Move all `\usepackage` out of `main.tex` into preamble:
+
+```latex
+% styles/preamble.tex
+\usepackage[margin=1in]{geometry}
+\usepackage{amsmath,amssymb}
+\usepackage{booktabs}
+\usepackage{float}
+\usepackage{graphicx}
+\usepackage{listings}
+\usepackage{xcolor}
+\usepackage{fancyhdr}
+\usepackage{siunitx}
+\usepackage{hyperref}          % load near end
+
+\graphicspath{{figures/}}
+```
+
+## `\input` vs `\include`
+
+| Command          | Behavior                         | Use Case                |
+|------------------|----------------------------------|-------------------------|
+| `\input{file}`   | Direct insertion, no page break  | Sections, short content |
+| `\include{file}` | Forces `\clearpage` before/after | Main chapters only      |
+
+Use `\includeonly{sections/02_methodology}` during drafting to
+compile only the current chapter — speeds up compilation.
+
+## Image Management
+
+- Use `\graphicspath{{figures/}}` so `\includegraphics` needs
+  only filenames, not paths.
+- For many images, use subfolders:
+  `\graphicspath{{figures/ch1/}{figures/ch2/}}`
+- Always use relative paths.
+
+## .gitignore for LaTeX
+
+```gitignore
+*.aux
+*.log
+*.out
+*.toc
+*.lof
+*.lot
+*.fls
+*.fdb_latexmk
+*.synctex.gz
+*.bbl
+*.blg
+```
+
+## Section File Naming
+
+- Always use numeric prefixes (`01_`, `02_`, ...).
+- Paper: name by paper structure (`01_introduction`).
+- Homework/report: name by topic (`01_forward_kinematics`).


### PR DESCRIPTION
## Summary

- Add `latex` skill with core conventions: xelatex engine, multi-step
  derivations (single `align` env with `&=` lines), boxed results,
  booktabs tables, label prefixes, text conventions, section decoration,
  standard preamble packages
- Add `references/project_structure.md` with directory layout, `main.tex`
  skeleton, preamble template, appendix support, and section naming for
  both papers and homework/reports
- Consolidate standalone `latex_workflow_project_structure.md` into skill

Closes #1

## Test plan

- [ ] Verify YAML frontmatter parses correctly in SKILL.md
- [ ] Confirm multi-step derivation rule is unambiguous
- [ ] Check project structure template covers paper and homework cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)